### PR TITLE
[bot] Add new workflow, 'arvis-mac-dark-mode'

### DIFF
--- a/docs/workflow-links.md
+++ b/docs/workflow-links.md
@@ -19,7 +19,7 @@ Note: Below table entries are sorted in extension name alphabetically.
 | [arvis-fkill](https://github.com/jopemachine/arvis-fkill)                             | Sam Verschueren          | Arvis workflow to fabulously search and kill processes   |  O  |  O  |   O   |
 | [arvis-font-awesome](https://github.com/jopemachine/arvis-font-awesome)               | SamVerschueren           | Arvis workflow to search for font-awesome icons          |  O  |  O  |   O   |
 | [arvis-loremipsum](https://github.com/jopemachine/arvis-loremipsum)                   | Anton Niklasson          | Lorem Ipsum generator in Arvis                           |  O  |  O  |   O   |
-| [arvis-mac-dark-mode](https://github.com/jopemachine/arvis-mac-dark-mode)             | Sindre Sorhus            | Arvis workflow to toggle the system dark mode            |  O  |  O  |   O   |
+| [arvis-mac-dark-mode](https://github.com/jopemachine/arvis-mac-dark-mode)             | Sindre Sorhus            | Arvis workflow to toggle the system dark mode            |  X  |  O  |   X   |
 | [arvis-mac-lock](https://github.com/jopemachine/arvis-mac-lock)                       | Sindre Sorhus            | Lock your Mac                                            |  X  |  O  |   X   |
 | [arvis-npms](https://github.com/jopemachine/arvis-npms)                               | Sindre Sorhus            | Arvis workflow to search for npm packages with npms.io   |  O  |  O  |   O   |
 | [arvis-packagist](https://github.com/jopemachine/arvis-packagist)                     | Vincent Klaiber          | Arvis workflow to search for PHP packages with Packagist |  O  |  O  |   O   |

--- a/internal/static-store.json
+++ b/internal/static-store.json
@@ -82,10 +82,13 @@
             "uploaded": 1625240254276
         },
         "Sindre Sorhus.arvis-mac-dark-mode": {
+            "platform": [
+                "darwin"
+            ],
             "description": "Arvis workflow to toggle the system dark mode",
             "creator": "Sindre Sorhus",
             "webAddress": "https://github.com/jopemachine/arvis-mac-dark-mode",
-            "uploaded": 1625241476961
+            "uploaded": 1625241667785
         }
     },
     "plugins": {


### PR DESCRIPTION
## Add new extension

* Type: 'workflow'
* Creator: 'Sindre Sorhus'
* Name: 'arvis-mac-dark-mode'
* Description: Arvis workflow to toggle the system dark mode